### PR TITLE
Change example over to safe code calls

### DIFF
--- a/examples/ceph.rs
+++ b/examples/ceph.rs
@@ -21,20 +21,10 @@ extern crate libc;
 use ceph_rust::JsonData;
 #[cfg(target_os = "linux")]
 use ceph_rust::admin_sockets::*;
-
 #[cfg(target_os = "linux")]
 use ceph_rust::ceph as ceph_helpers;
 #[cfg(target_os = "linux")]
 use ceph_rust::rados as ceph;
-use libc::*;
-use std::{ptr, slice, str};
-use std::ffi::{CStr, CString};
-
-macro_rules! zeroed_c_char_buf {
-	($n:expr) => {
-		repeat(0).take($n).collect::<Vec<c_char>>();
-	}
-}
 
 #[cfg(not(target_os = "linux"))]
 fn main() {}
@@ -43,15 +33,7 @@ fn main() {}
 
 #[cfg(target_os = "linux")]
 fn main() {
-    let mut major: i32 = 0;
-    let mut minor: i32 = 0;
-    let mut extra: i32 = 0;
-
-    let config_file = CString::new("/etc/ceph/ceph.conf").unwrap();
-    let pool_name = CString::new("lsio").unwrap();
-    let mut cluster: ceph::rados_t = std::ptr::null_mut();
-    let mut ret_code: i32;
-
+    let pool_name = "lsio";
     // NB: These examples (except for a few) are low level examples that require the unsafe block.
     // However, work for the higher level pur Rust is being worked on in the ceph.rs module of
     // the library. A few of those are present below. We will create a common Result or Option
@@ -67,87 +49,63 @@ fn main() {
         },
     }
 
-    ceph::rados_libversion(&mut major, &mut minor, &mut extra);
-    ret_code = ceph::rados_create(&mut cluster, std::ptr::null());
-    println!("Return code: {} - {:?}", ret_code, cluster);
-    unsafe {
+    let rados_version = ceph_helpers::rados_libversion();
+    println!("Librados version: {:?}", rados_version);
+    let cluster = ceph_helpers::connect_to_ceph("admin", "/etc/ceph/ceph.conf").unwrap();
+    ceph_helpers::rados_create_pool(cluster, pool_name).unwrap();
 
-        ret_code = ceph::rados_conf_read_file(cluster, config_file.as_ptr());
-        println!("Return code: {} - {:?}", ret_code, cluster);
+    let pools_list = ceph_helpers::rados_pools(cluster).unwrap();
+    println!("{:?}", pools_list);
 
-        ret_code = ceph::rados_connect(cluster);
-        println!("Return code: {} - {:?}", ret_code, cluster);
+    ceph_helpers::rados_delete_pool(cluster, pool_name).unwrap();
 
-        ret_code = ceph::rados_pool_create(cluster, pool_name.as_ptr());
-        println!("Return code: {}", ret_code);
+    let fsid = ceph_helpers::rados_fsid(cluster).unwrap();
+    println!("rados_cluster_fsid {}", fsid);
 
-        let pools_list = ceph_helpers::rados_pools(cluster).unwrap();
-        println!("{:?}", pools_list);
+    let cluster_stat = ceph_helpers::rados_stat_cluster(cluster).unwrap();
+    println!("Cluster stat: {:?}", cluster_stat);
 
-        ret_code = ceph::rados_pool_delete(cluster, pool_name.as_ptr());
-        println!("Return code: {}", ret_code);
+    // Print CephHealth of cluster
+    println!("{}", ceph_helpers::ceph_health_string(cluster).unwrap_or("".to_string()));
 
-        let instance_id = ceph::rados_get_instance_id(cluster);
-        println!("Instance ID: {}", instance_id);
-
-        let buf_size: usize = 37; // 36 is the constant size +1 for null.
-        let mut fs_id: Vec<u8> = Vec::with_capacity(buf_size);
-
-        let len = ceph::rados_cluster_fsid(cluster, fs_id.as_mut_ptr() as *mut c_char, buf_size);
-        let slice = slice::from_raw_parts(fs_id.as_mut_ptr(), buf_size - 1);
-        let s: &str = str::from_utf8(slice).unwrap();
-        println!("rados_cluster_fsid len: {} - {}", len, s);
-
-        // Rust specific example...
-        let cluster_stat = ceph_helpers::rados_stat_cluster(cluster);
-        println!("Cluster stat: {:?}", cluster_stat);
-
-        // Mon command to check the health. Same as `ceph -s`
-        match ceph_helpers::ceph_mon_command(cluster, "prefix", "status", None) {
-            Ok((outbuf, outs)) => {
-                match outbuf {
-                    Some(output) => println!("Ceph mon command (outbuf):\n{}", output),
-                    None => {},
-                }
-                match outs {
-                    Some(output) => println!("Ceph mon command (outs):\n{}", output),
-                    None => {},
-                }
-            },
-            Err(e) => {
-                println!("{:?}", e);
-            },
-        }
-
-        // Print CephHealth of cluster
-        println!("{}", ceph_helpers::ceph_health_string(cluster).unwrap_or("".to_string()));
-
-        // Print Status of cluster health a different way
-        println!("{}", ceph_helpers::ceph_status(cluster, &["health", "overall_status"]).unwrap());
-
-        // This command encapsulates the lower level mon, osd, pg commands and returns JsonData
-        // objects based on the key path
-        println!("{:?}",
-                 ceph_helpers::ceph_command(cluster,
-                                            "prefix",
-                                            "status",
-                                            ceph_helpers::CephCommandTypes::Mon,
-                                            &["health"]));
-
-        // Get a list of Ceph librados commands in JSON format.
-        // It's very long so it's commented out.
-        // println!("{}", ceph_helpers::ceph_commands(cluster, None).unwrap().pretty());
-
-        // Currently - parses the `ceph --version` call. The admin socket commands `version`
-        // and `git_version`
-        // will be called soon to replace the string parse.
-        // Change to the real mon admin socket name
-        let ceph_ver = ceph_helpers::ceph_version("/var/run/ceph/ceph-mon.ceph-vm1.asok");
-        println!("Ceph Version - {:?}", ceph_ver);
-
-        ceph::rados_shutdown(cluster);
+    // Print Status of cluster health a different way
+    println!("{}", ceph_helpers::ceph_status(cluster, &["health", "overall_status"]).unwrap());
+    // Currently - parses the `ceph --version` call. The admin socket commands `version`
+    // and `git_version`
+    // will be called soon to replace the string parse.
+    // Change to the real mon admin socket name
+    let ceph_ver = ceph_helpers::ceph_version("/var/run/ceph/ceph-mon.ceph-vm1.asok");
+    println!("Ceph Version - {:?}", ceph_ver);
+    // Mon command to check the health. Same as `ceph -s`
+    match ceph_helpers::ceph_mon_command(cluster, "prefix", "status", None) {
+        Ok((outbuf, outs)) => {
+            match outbuf {
+                Some(output) => println!("Ceph mon command (outbuf):\n{}", output),
+                None => {},
+            }
+            match outs {
+                Some(output) => println!("Ceph mon command (outs):\n{}", output),
+                None => {},
+            }
+        },
+        Err(e) => {
+            println!("{:?}", e);
+        },
     }
 
-    println!("RADOS Version - v{}.{}.{}", major, minor, extra);
+    // This command encapsulates the lower level mon, osd, pg commands and returns JsonData
+    // objects based on the key path
+    println!("{:?}",
+             ceph_helpers::ceph_command(cluster, "prefix", "status", ceph_helpers::CephCommandTypes::Mon, &["health"]));
 
+    // Get a list of Ceph librados commands in JSON format.
+    // It's very long so it's commented out.
+    // println!("{}", ceph_helpers::ceph_commands(cluster, None).unwrap().pretty());
+    unsafe {
+        let instance_id = ceph::rados_get_instance_id(cluster);
+        println!("Instance ID: {}", instance_id);
+    }
+
+    ceph_helpers::disconnect_from_ceph(cluster);
+    println!("RADOS Version - v{}.{}.{}", rados_version.major, rados_version.minor, rados_version.extra);
 }

--- a/examples/ceph.rs
+++ b/examples/ceph.rs
@@ -40,7 +40,7 @@ fn main() {
     // return and allow for pattern matching.
 
     // Example of accessing the `Admin Socket` for mon
-    match admin_socket_command("help", "/var/run/ceph/ceph-mon.ceph-vm1.asok") {
+    match admin_socket_command("help", "/var/run/ceph/ceph-mon.ip-172-31-31-247.asok") {
         Ok(json) => {
             println!("{}", json);
         },
@@ -51,16 +51,24 @@ fn main() {
 
     let rados_version = ceph_helpers::rados_libversion();
     println!("Librados version: {:?}", rados_version);
+
+    println!("Connecting to ceph");
     let cluster = ceph_helpers::connect_to_ceph("admin", "/etc/ceph/ceph.conf").unwrap();
+    println!("Creating pool {}", pool_name);
     ceph_helpers::rados_create_pool(cluster, pool_name).unwrap();
 
+    println!("Listing pools");
     let pools_list = ceph_helpers::rados_pools(cluster).unwrap();
-    println!("{:?}", pools_list);
+	for pool in pools_list{
+		println!("pool: {}", pool);
+	}
 
+    println!("Deleting pool: {}", pool_name);
     ceph_helpers::rados_delete_pool(cluster, pool_name).unwrap();
 
-    let fsid = ceph_helpers::rados_fsid(cluster).unwrap();
-    println!("rados_cluster_fsid {}", fsid);
+    println!("Getting cluster fsid");
+    let fsid = ceph_helpers::rados_fsid(cluster);
+    println!("rados_cluster_fsid {:?}", fsid);
 
     let cluster_stat = ceph_helpers::rados_stat_cluster(cluster).unwrap();
     println!("Cluster stat: {:?}", cluster_stat);
@@ -74,7 +82,7 @@ fn main() {
     // and `git_version`
     // will be called soon to replace the string parse.
     // Change to the real mon admin socket name
-    let ceph_ver = ceph_helpers::ceph_version("/var/run/ceph/ceph-mon.ceph-vm1.asok");
+    let ceph_ver = ceph_helpers::ceph_version("/var/run/ceph/ceph-mon.ip-172-31-31-247.asok");
     println!("Ceph Version - {:?}", ceph_ver);
     // Mon command to check the health. Same as `ceph -s`
     match ceph_helpers::ceph_mon_command(cluster, "prefix", "status", None) {
@@ -102,6 +110,7 @@ fn main() {
     // It's very long so it's commented out.
     // println!("{}", ceph_helpers::ceph_commands(cluster, None).unwrap().pretty());
     unsafe {
+		println!("Getting rados instance id");
         let instance_id = ceph::rados_get_instance_id(cluster);
         println!("Instance ID: {}", instance_id);
     }


### PR DESCRIPTION
I'm doing a little preflight check before the tech talk next week.

I modified the example a little and just swapped out the unsafe for safe calls. 
I caught a problem with the rados_fsid parsing function.  I'm not sure how I missed that before.  I must've forgotten to test it.  I tested it against a ceph jewel cluster running on ec2 and noticed ceph is returning a hyphenated uuid string not just a simple uuid string like I had thought.  I also noticed an intermittent failure with the ceph_mon_command_with_data  function.  I don't know yet what is triggering it.  I can run it several times in a row and it's fine and then the next one will panic.  