### PR TITLE
Ceph mon command without data

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ for development etc. See README.md for details.
 bitflags = "~0.7"
 byteorder = "1" #"~0.5"
 libc = "0.2"
+log = "~0.3"
 nom = "~1.2"
 uuid = {version = "~0.3", features = ["use_std"] }
 rustc-serialize = "~0.3"

--- a/src/ceph.rs
+++ b/src/ceph.rs
@@ -1801,6 +1801,7 @@ pub fn ceph_mon_command_without_data(cluster: rados_t, cmd: &str) -> RadosResult
                                          data.len() as usize, &mut outbuf,
                                          &mut outbuf_len, &mut outs,
                                          &mut outs_len);
+        debug!("return code: {}", ret_code);
         if ret_code < 0 {
             return Err(RadosError::new(try!(get_error(ret_code))));
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,8 +17,10 @@
        html_favicon_url = "https://lambdastackio.github.io/static/images/favicon.ico",
        html_root_url = "https://lambdastackio.github.io/aws-sdk-rust/ceph-rust/ceph_rust/index.html")]
 
-//! Ceph-rust is a thin layer over the librados C interface. A little higher abstraction layer will
-//! be coming next that will encapsulate all of the "C" specific features so that only pure Rust will be needed.
+//! Ceph-rust is a thin layer over the librados C interface. A little higher
+//! abstraction layer will
+//! be coming next that will encapsulate all of the "C" specific features so
+//! that only pure Rust will be needed.
 //!
 //! Only works on Linux
 //! The documentation for librados can be found:
@@ -39,7 +41,8 @@
 //! Ubuntu:
 //! sudo ln -s /usr/lib/librados.so.2.0.0 /usr/lib/librados.so
 //!
-//! NOTE: If someone know of another way for Rust to find the librados file then please issue
+//! NOTE: If someone know of another way for Rust to find the librados file
+//! then please issue
 //! a PR for it. Thanks!
 //!
 //! See the /examples/ceph.rs for how to use the library.
@@ -48,6 +51,8 @@
 extern crate bitflags;
 extern crate byteorder;
 extern crate libc;
+#[macro_use]
+extern crate log;
 #[macro_use]
 extern crate nom;
 extern crate uuid;


### PR DESCRIPTION
I've created a new fn to call ceph mon commands without additional data.  This was very useful for calling ceph commands without having to use std::process::Command;  I also ran rustfmt over the source.  If this PR is too noisy I can separate the formatting out into another one.  

The main fn is here: https://github.com/ceph/ceph-rust/pull/9/files#diff-8739a9eb534a789b590610dda9e747e7R1851