### PR TITLE
Remove nulls from pool strings

### DIFF
--- a/src/ceph.rs
+++ b/src/ceph.rs
@@ -1432,7 +1432,7 @@ pub fn rados_pools(cluster: rados_t) -> RadosResult<Vec<String>> {
             break;
         } else {
             // Read a String
-            pools.push(String::from_utf8_lossy(&string_buf).into_owned());
+            pools.push(String::from_utf8_lossy(&string_buf[..read-1]).into_owned());
         }
     }
 


### PR DESCRIPTION
Super easy one.  I was testing a little piece of code and noticed I left the null bytes ceph was returning in the strings.  When you pass that back into ceph it blows up.  This fixes that.