### PR TITLE
Add Sync trait

### DIFF
--- a/src/ceph.rs
+++ b/src/ceph.rs
@@ -333,6 +333,8 @@ pub struct Rados {
     phantom: PhantomData<IoCtx>,
 }
 
+unsafe impl Sync for Rados{}
+
 impl Drop for Rados {
     fn drop(&mut self) {
         if !self.rados.is_null() {


### PR DESCRIPTION
After talking with the ceph devs they told me that the rados
connection is thread safe.  This change adds the impl to the
struct allowing the rados connection to be shared between
threads.  In a very small testing situation I found this
greatly speeds up calls to ceph.