### PR TITLE
Support building on macOS and other unix platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,23 @@ Official Ceph Rust-lang interface. Contributions welcomed!
 
 This library is the core librados Rust interface for Ceph. It also supports Admin Socket commands.
 
+### Build requirements
+
+Librados must be installed.
+
+On CentOS/RHEL - Ceph Hammer librados is located in /usr/lib64. So, to get rust to see it you need to create a new symlink:
+sudo ln -s /usr/lib64/librados.so.2.0.0 /usr/lib64/librados.so
+
+On Ubuntu - Ceph Hammer librados is located in /usr/lib. So, to get rust to see it you need to create a new symlink:
+sudo ln -s /usr/lib/librados.so.2.0.0 /usr/lib/librados.so
+
+There may be another way to change the link name in rust without having to create a symlink.
+
+On MacOS, you can install librados via homebrew:
+
+brew tap zeichenanonym/ceph-client
+brew install ceph-client
+
 ### Ceph
 Create a Ceph development environment or use an existing Ceph environment.
 
@@ -34,15 +51,6 @@ Once complete you can then login to the first node:
 vagrant ssh ceph-vm1
 
 Run ceph -s to make sure you see Ceph running. Now you can install the development environment and Rust.
-
-#### Important
-NOTE: CentOS/RHEL - Ceph Hammer librados is located in /usr/lib64. So, to get rust to see it you need to create a new symlink:
-sudo ln -s /usr/lib64/librados.so.2.0.0 /usr/lib64/librados.so
-
-NOTE: Ubuntu - Ceph Hammer librados is located in /usr/lib. So, to get rust to see it you need to create a new symlink:
-sudo ln -s /usr/lib/librados.so.2.0.0 /usr/lib/librados.so
-
-There may be another way to change the link name in rust without having to create a symlink.
 
 ### Rust
 (In ceph-vm1 node)

--- a/examples/ceph.rs
+++ b/examples/ceph.rs
@@ -18,19 +18,19 @@ extern crate ceph;
 extern crate libc;
 
 use ceph::JsonData;
-#[cfg(target_os = "linux")]
+#[cfg(unix)]
 use ceph::admin_sockets::*;
-#[cfg(target_os = "linux")]
+#[cfg(unix)]
 use ceph::ceph as ceph_helpers;
-#[cfg(target_os = "linux")]
+#[cfg(unix)]
 use ceph::rados;
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(unix))]
 fn main() {}
 
 // NB: The examples below show a mix of raw native access and rust specific calls.
 
-#[cfg(target_os = "linux")]
+#[cfg(unix)]
 fn main() {
     let pool_name = "lsio";
     // NB: These examples (except for a few) are low level examples that require the unsafe block.

--- a/src/admin_sockets.rs
+++ b/src/admin_sockets.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![cfg(target_os = "linux")]
+#![cfg(unix)]
 
 use byteorder::{BigEndian, ReadBytesExt};
 

--- a/src/ceph.rs
+++ b/src/ceph.rs
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#![cfg(target_os = "linux")]
+#![cfg(unix)]
 #![allow(unused_imports)]
 
 use JsonData;

--- a/src/rados.rs
+++ b/src/rados.rs
@@ -195,7 +195,7 @@ pub type rados_log_callback_t = ::std::option::Option<
     ) -> (),
 >;
 
-#[cfg(target_os = "linux")]
+#[cfg(unix)]
 #[link(name = "rados", kind = "dylib")]
 extern "C" {
     pub fn rados_version(major: *mut ::libc::c_int, minor: *mut ::libc::c_int, extra: *mut ::libc::c_int) -> ();


### PR DESCRIPTION
This makes it possible to check the code compiles without having to copy it across to a Linux machine.

In the future it may be worth removing these completely, or adding them to all of the crate's files - at the moment as only some parts of the code are flagged, other parts like cmd.rs spit out errors when on a non-supported platform.