### PR TITLE
Remove old dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,6 @@ serde_derive = "1"
 serde = "1"
 serde_json = "1"
 uuid = {version = "~0.7", features = ["serde"] }
-rustc-serialize = "~0.3"
 nix = "0.14"
 
 [features]

--- a/src/json.rs
+++ b/src/json.rs
@@ -14,7 +14,7 @@
 
 use std::str;
 
-use rustc_serialize::json::*;
+use serde_json;
 
 use JsonData;
 // use JsonValue;
@@ -23,7 +23,7 @@ use JsonData;
 /// JsonData object that can then be traversed using `json_find` via the key
 /// path.
 pub fn json_data(json_str: &str) -> Option<JsonData> {
-    match Json::from_str(json_str) {
+    match serde_json::from_str(json_str) {
         Ok(json_data) => Some(json_data),
         Err(_) => None,
     }
@@ -34,10 +34,18 @@ pub fn json_data(json_str: &str) -> Option<JsonData> {
 /// object is used for situations where there may be 'child' objects with the
 /// same name.
 pub fn json_find(json_data: JsonData, keys: &[&str]) -> Option<JsonData> {
-    json_data.find_path(keys).cloned()
+    let mut value = json_data;
+    for key in keys {
+        match value.get(key) {
+            Some(v) => value = v.clone(),
+            None => return None,
+        }
+    }
+
+    Some(value)
 }
 
 /// More specific String cast of an individual JsonData object.
 pub fn json_as_string(json_data: &JsonData) -> String {
-    json_data.as_string().unwrap_or("").to_string()
+    json_data.to_string()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,6 @@ extern crate libc;
 extern crate log;
 #[macro_use]
 extern crate nom;
-extern crate rustc_serialize;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;
@@ -71,7 +70,8 @@ pub mod cmd;
 pub mod error;
 pub mod json;
 pub mod rados;
-#[cfg(feature = "rados_striper")] pub mod rados_striper;
+#[cfg(feature = "rados_striper")]
+pub mod rados_striper;
 pub mod status;
 pub mod utils;
 
@@ -84,5 +84,5 @@ pub use ceph_version::CephVersion;
 pub use cmd::{OsdOption, PoolOption};
 pub use mon_command::MonCommand;
 
-pub type JsonData = rustc_serialize::json::Json;
-pub type JsonValue = rustc_serialize::json::Json;
+pub type JsonData = serde_json::Value;
+pub type JsonValue = serde_json::Value;

--- a/src/status.rs
+++ b/src/status.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[derive(RustcDecodable, RustcEncodable)]
+#[derive(Deserialize, Serialize)]
 pub struct CephStatus {
     health: CephStatusHealth,
     fsid: String,
@@ -25,7 +25,7 @@ pub struct CephStatus {
     mdsmap: CephStatusMDSMap,
 }
 
-#[derive(RustcDecodable, RustcEncodable)]
+#[derive(Deserialize, Serialize)]
 pub struct CephStatusHealth {
     health: CephStatusHealth2,
     timechecks: CephStatusHealthTimeChecks,
@@ -34,17 +34,17 @@ pub struct CephStatusHealth {
     detail: Vec<CephStatusHealthDetail>,
 }
 
-#[derive(RustcDecodable, RustcEncodable)]
+#[derive(Deserialize, Serialize)]
 pub struct CephStatusHealth2 {
     health: Vec<CephStatusHealthServices>,
 }
 
-#[derive(RustcDecodable, RustcEncodable)]
+#[derive(Deserialize, Serialize)]
 pub struct CephStatusHealthServices {
     mons: Vec<CephStatusHealthServicesMon>,
 }
 
-#[derive(RustcDecodable, RustcEncodable)]
+#[derive(Deserialize, Serialize)]
 pub struct CephStatusHealthServicesMon {
     name: String,
     kb_total: u32,
@@ -56,7 +56,7 @@ pub struct CephStatusHealthServicesMon {
     health: String,
 }
 
-#[derive(RustcDecodable, RustcEncodable)]
+#[derive(Deserialize, Serialize)]
 pub struct CephStatusHealthServicesMonStats {
     bytes_total: u64,
     bytes_sst: u64,
@@ -65,7 +65,7 @@ pub struct CephStatusHealthServicesMonStats {
     last_updated: String,
 }
 
-#[derive(RustcDecodable, RustcEncodable)]
+#[derive(Deserialize, Serialize)]
 pub struct CephStatusHealthTimeChecks {
     epoch: u32,
     round: u32,
@@ -73,7 +73,7 @@ pub struct CephStatusHealthTimeChecks {
     mons: Vec<CephStatusHealthMons>,
 }
 
-#[derive(RustcDecodable, RustcEncodable)]
+#[derive(Deserialize, Serialize)]
 pub struct CephStatusHealthMons {
     name: String,
     skew: f32,
@@ -81,18 +81,18 @@ pub struct CephStatusHealthMons {
     health: String,
 }
 
-#[derive(RustcDecodable, RustcEncodable)]
+#[derive(Deserialize, Serialize)]
 pub struct CephStatusHealthSummary {
     severity: String,
     summary: String,
 }
 
-#[derive(RustcDecodable, RustcEncodable)]
+#[derive(Deserialize, Serialize)]
 pub struct CephStatusHealthDetail {
     dummy: String,
 }
 
-#[derive(RustcDecodable, RustcEncodable)]
+#[derive(Deserialize, Serialize)]
 pub struct CephStatusMonMap {
     epoch: u32,
     fsid: String,
@@ -101,19 +101,19 @@ pub struct CephStatusMonMap {
     mons: Vec<CephStatusMonRank>,
 }
 
-#[derive(RustcDecodable, RustcEncodable)]
+#[derive(Deserialize, Serialize)]
 pub struct CephStatusMonRank {
     rank: u16,
     name: String,
     addr: String,
 }
 
-#[derive(RustcDecodable, RustcEncodable)]
+#[derive(Deserialize, Serialize)]
 pub struct CephStatusOSDMapH {
     osdmap: CephStatusOSDMapL,
 }
 
-#[derive(RustcDecodable, RustcEncodable)]
+#[derive(Deserialize, Serialize)]
 pub struct CephStatusOSDMapL {
     epoch: u32,
     num_osds: u32,
@@ -124,7 +124,7 @@ pub struct CephStatusOSDMapL {
     num_remapped_pgs: u32,
 }
 
-#[derive(RustcDecodable, RustcEncodable)]
+#[derive(Deserialize, Serialize)]
 pub struct CephStatusPGMap {
     pgs_by_state: Vec<CephStatusPGState>,
     version: u32,
@@ -135,13 +135,13 @@ pub struct CephStatusPGMap {
     bytes_total: u64,
 }
 
-#[derive(RustcDecodable, RustcEncodable)]
+#[derive(Deserialize, Serialize)]
 pub struct CephStatusPGState {
     state_name: String,
     count: u32,
 }
 
-#[derive(RustcDecodable, RustcEncodable)]
+#[derive(Deserialize, Serialize)]
 pub struct CephStatusMDSMap {
     epoch: u32,
     up: u32,
@@ -150,7 +150,7 @@ pub struct CephStatusMDSMap {
     by_rank: Vec<CephStatusMDSRank>,
 }
 
-#[derive(RustcDecodable, RustcEncodable)]
+#[derive(Deserialize, Serialize)]
 pub struct CephStatusMDSRank {
     rank: u16,
     name: String,


### PR DESCRIPTION
This patch removes the deprecated rustc-serialize crate in favor of serde. Since serde was already imported, the transition was pretty straightforward. The only thing I was unsure of was replacing the `find_path` function with consecutive `get` calls. I think I maintained the behavior but will continue testing it locally.