### PR TITLE
parse Unknown Lvm Json

### DIFF
--- a/src/ceph_version.rs
+++ b/src/ceph_version.rs
@@ -67,9 +67,9 @@ impl FromStr for CephVersion {
                         "61" => return Ok(Cuttlefish),
                         "56" => return Ok(Bobtail),
                         "48" => return Ok(Argonaut),
-                        _ => {}
+                        _ => {},
                     },
-                    _ => {}
+                    _ => {},
                 }
             }
         }

--- a/src/ceph_volume.rs
+++ b/src/ceph_volume.rs
@@ -89,6 +89,12 @@ pub enum LvmData {
         #[serde(flatten)]
         other_meta: Option<HashMap<String, String>>,
     },
+    // unknown type of ceph-volume lvm list output
+    Unknown {
+        //unknown metadata not captured through the above attributes
+        #[serde(flatten)]
+        unknown_meta: Option<HashMap<String, String>>,
+    },
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]

--- a/src/ceph_volume.rs
+++ b/src/ceph_volume.rs
@@ -54,6 +54,9 @@ pub struct LvmTags {
     pub wal_device: Option<String>,
     #[serde(rename = "ceph.wal_uuid")]
     pub wal_uuid: Option<String>,
+    //Other tags that are not listed here
+    #[serde(flatten)]
+    pub other_tags: Option<HashMap<String, String>>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -69,12 +72,29 @@ pub struct LvmMeta {
     #[serde(rename = "type")]
     pub lv_type: String,
     pub vg_name: String,
+    // other metadata not captured through the above attributes
+    #[serde(flatten)]
+    pub other_meta: Option<HashMap<String, String>>,
+}
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(untagged)]
+pub enum LvmData {
+    Osd(LvmMeta),
+    Journal {
+        path: Option<String>,
+        tags: Option<HashMap<String, String>>,
+        #[serde(rename = "type")]
+        j_type: Option<String>,
+        // other metadata not captured through the above attributes
+        #[serde(flatten)]
+        other_meta: Option<HashMap<String, String>>,
+    },
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct Lvm {
     #[serde(flatten)]
-    pub metadata: LvmMeta,
+    pub metadata: LvmData,
 }
 
 // Check the cluster version. If version < Luminous, error out

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -9,10 +9,7 @@ extern crate serde_json;
 
 use crate::ceph::Rados;
 use crate::error::{RadosError, RadosResult};
-<<<<<<< HEAD
 use crate::CephVersion;
-=======
->>>>>>> update to rust 2018 edition
 use std::collections::HashMap;
 use std::fmt;
 use std::str::FromStr;

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -845,6 +845,17 @@ pub fn osd_crush_remove(cluster_handle: &Rados, osd_id: u64, simulate: bool) -> 
     Ok(())
 }
 
+/// Get a list of all pools in the cluster
+pub fn osd_pool_ls(cluster_handle: &Rados) -> RadosResult<Vec<String>> {
+    let cmd = json!({
+        "prefix": "osd pool ls",
+        "format": "json",
+    });
+    let result = cluster_handle.ceph_mon_command_without_data(&cmd)?;
+    let return_data = String::from_utf8(result.0)?;
+    Ok(serde_json::from_str(&return_data)?)
+}
+
 /// Query a ceph pool.
 pub fn osd_pool_get(cluster_handle: &Rados, pool: &str, choice: &PoolOption) -> RadosResult<String> {
     let cmd = json!({

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -9,7 +9,10 @@ extern crate serde_json;
 
 use crate::ceph::Rados;
 use crate::error::{RadosError, RadosResult};
+<<<<<<< HEAD
 use crate::CephVersion;
+=======
+>>>>>>> update to rust 2018 edition
 use std::collections::HashMap;
 use std::fmt;
 use std::str::FromStr;


### PR DESCRIPTION
Added parsing of Journal LVM, as well as parsing of unknown fields via Option<Hashmap<String, String>> fields (They capture undefined JSON fields as HashMaps, for example, lv_size, which is not strictly defined in LvmMeta but can be a field output of ceph-volume lvm list) Essentially any tags/fields that aren't explicitly listed (unless the device type is unknown) should be captured by the HashMaps if there are any.