### PR TITLE
Add osd_meta fields to OsdMetadata, MgrMetadata, and PgSummary

### DIFF
--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -72,6 +72,9 @@ pub struct MgrMetadata {
     #[serde(flatten)]
     pub mem: Mem,
     pub os: String,
+    // other metadata not captured through the above attributes
+    #[serde(flatten)]
+    other_meta: Option<HashMap<String, String>>,
 }
 
 #[serde(rename_all = "lowercase")]
@@ -173,6 +176,9 @@ pub struct OsdMetadata {
     pub rotational: Option<String>, //Not in Jewel
     #[serde(flatten)]
     pub objectstore_meta: ObjectStoreMeta,
+    // other metadata not captured through the above attributes
+    #[serde(flatten)]
+    other_meta: Option<HashMap<String, String>>,
 }
 
 #[derive(Deserialize, Debug, Clone)]
@@ -208,7 +214,10 @@ pub struct PgSummary {
     pub recovering_keys_per_sec: Option<u64>,
     pub num_objects_recovered: Option<u64>,
     pub num_bytes_recovered: Option<u64>,
-    pub num_keys_revocered: Option<u64>,
+    pub num_keys_recovered: Option<u64>,
+    // other metadata not captured through the above attributes
+    #[serde(flatten)]
+    other_meta: Option<HashMap<String, String>>,
 }
 
 #[derive(Deserialize, Debug, Clone)]


### PR DESCRIPTION
 Capture fields that might not be listed explicitly.  There might be repeats, but it WILL capture any fields that have not been explicitly listed