### PR TITLE
Update dependencies to latest versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,12 +35,12 @@ edition = "2018"
 bitflags = "1.2.1"
 byteorder = "1"
 libc = "~0.2"
-nom = "5"
+nom = "6"
 serde_derive = "1"
 serde = "1"
 serde_json = "1"
 uuid = { version = "~0.8", features = ["serde"] }
-nix = "0.18"
+nix = "0.21"
 tracing = "0.1"
 
 [features]

--- a/src/ceph.rs
+++ b/src/ceph.rs
@@ -1220,12 +1220,12 @@ impl IoCtx {
             Input from Ceph was too small.  Needed: {:?} more bytes",
                 needed
             ))),
-            Err(nom::Err::Error((e, _))) => {
-                Err(RadosError::new(String::from_utf8_lossy(e).to_string()))
-            }
-            Err(nom::Err::Failure((e, _))) => {
-                Err(RadosError::new(String::from_utf8_lossy(e).to_string()))
-            }
+            Err(nom::Err::Error(e)) => Err(RadosError::new(
+                String::from_utf8_lossy(e.input).to_string(),
+            )),
+            Err(nom::Err::Failure(e)) => Err(RadosError::new(
+                String::from_utf8_lossy(e.input).to_string(),
+            )),
         }
     }
 


### PR DESCRIPTION
(By running 'cargo outdated')

This shouldn't break (or fix) anything, but it makes
the crate friendlier to consume for other crates using
latest libraries.

For example, other crates might want to compare ApiErrors
via nix::errno::Errno (where they are using latest nix)