### PR TITLE
async/await compatible wrapper for librados AIO methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ serde_json = "1"
 uuid = { version = "~0.8", features = ["serde"] }
 nix = "0.21"
 tracing = "0.1"
+futures = {version="~0.3", features=["thread-pool"]}
 
 [features]
 default = []

--- a/src/ceph.rs
+++ b/src/ceph.rs
@@ -42,6 +42,7 @@ use std::net::IpAddr;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use crate::list_stream::ListStream;
+use crate::read_stream::ReadStream;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
@@ -1070,6 +1071,15 @@ impl IoCtx {
         }
 
         result
+    }
+
+    /// Streaming read of a RADOS object.  The `ReadStream` object implements `futures::Stream`
+    /// for use with Stream-aware code like hyper's Body::wrap_stream.
+    ///
+    /// This will usually issue more read ops than needed if used on a small object: for
+    /// small objects `rados_async_object_read` is more appropriate.
+    pub fn rados_async_object_read_stream(&self, object_name: &str) -> ReadStream<'_> {
+        ReadStream::new(self, object_name, None, None)
     }
 
     /// Get object stats (size,SystemTime)

--- a/src/ceph.rs
+++ b/src/ceph.rs
@@ -39,6 +39,9 @@ use std::io::{BufRead, Cursor};
 use std::net::IpAddr;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
 use uuid::Uuid;
 
 const CEPH_OSD_TMAP_HDR: char = 'h';
@@ -332,7 +335,8 @@ impl Iterator for XAttr {
 
 /// Owns a ioctx handle
 pub struct IoCtx {
-    ioctx: rados_ioctx_t,
+    // This is pub within the crate to enable Completions to use it
+    pub(crate) ioctx: rados_ioctx_t,
 }
 
 unsafe impl Send for IoCtx {}

--- a/src/ceph.rs
+++ b/src/ceph.rs
@@ -1094,6 +1094,75 @@ impl IoCtx {
         Ok((psize, (UNIX_EPOCH + Duration::from_secs(time as u64))))
     }
 
+    /// Async variant of rados_object_getxattr
+    pub async fn rados_async_object_getxattr(
+        &self,
+        object_name: &str,
+        attr_name: &str,
+        fill_buffer: &mut [u8],
+    ) -> RadosResult<i32> {
+        self.ioctx_guard()?;
+        let object_name_str = CString::new(object_name)?;
+        let attr_name_str = CString::new(attr_name)?;
+
+        with_completion(self, |c| unsafe {
+            rados_aio_getxattr(
+                self.ioctx,
+                object_name_str.as_ptr() as *const c_char,
+                c,
+                attr_name_str.as_ptr() as *const c_char,
+                fill_buffer.as_mut_ptr() as *mut c_char,
+                fill_buffer.len(),
+            )
+        })?
+        .await
+    }
+
+    /// Async variant of rados_object_setxattr
+    pub async fn rados_async_object_setxattr(
+        &self,
+        object_name: &str,
+        attr_name: &str,
+        attr_value: &[u8],
+    ) -> RadosResult<i32> {
+        self.ioctx_guard()?;
+        let object_name_str = CString::new(object_name)?;
+        let attr_name_str = CString::new(attr_name)?;
+
+        with_completion(self, |c| unsafe {
+            rados_aio_setxattr(
+                self.ioctx,
+                object_name_str.as_ptr() as *const c_char,
+                c,
+                attr_name_str.as_ptr() as *const c_char,
+                attr_value.as_ptr() as *mut c_char,
+                attr_value.len(),
+            )
+        })?
+        .await
+    }
+
+    /// Async variant of rados_object_rmxattr
+    pub async fn rados_async_object_rmxattr(
+        &self,
+        object_name: &str,
+        attr_name: &str,
+    ) -> RadosResult<i32> {
+        self.ioctx_guard()?;
+        let object_name_str = CString::new(object_name)?;
+        let attr_name_str = CString::new(attr_name)?;
+
+        with_completion(self, |c| unsafe {
+            rados_aio_rmxattr(
+                self.ioctx,
+                object_name_str.as_ptr() as *const c_char,
+                c,
+                attr_name_str.as_ptr() as *const c_char,
+            )
+        })?
+        .await
+    }
+
     /// Efficiently copy a portion of one object to another
     /// If the underlying filesystem on the OSD supports it, this will be a
     /// copy-on-write clone.

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -1,0 +1,161 @@
+// Copyright 2021 John Spray All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::ffi::c_void;
+use std::pin::Pin;
+use std::sync::Mutex;
+use std::task::{Context, Poll, Waker};
+
+use crate::ceph::IoCtx;
+use crate::error::RadosResult;
+use crate::rados::{
+    rados_aio_cancel, rados_aio_create_completion2, rados_aio_get_return_value,
+    rados_aio_is_complete, rados_aio_release, rados_aio_wait_for_complete_and_cb,
+    rados_completion_t,
+};
+
+pub(crate) struct Completion<'a> {
+    inner: rados_completion_t,
+
+    // Box to provide a stable address for completion_complete callback
+    // Mutex for memory fencing when writing from poll() and reading from completion_complete()
+    waker: Box<std::sync::Mutex<Option<std::task::Waker>>>,
+
+    // A reference to the IOCtx is required to issue a cancel on
+    // the operation if we are dropped before ready.  This needs
+    // to be a Rust reference rather than a raw rados_ioctx_t because otherwise
+    // there would be nothing to stop the rados_ioctx_t being invalidated
+    // during the lifetime of this Completion.
+    // (AioCompletionImpl does hold a reference to IoCtxImpl for writes, but
+    //  not for reads.)
+    ioctx: &'a IoCtx,
+}
+
+unsafe impl Send for Completion<'_> {}
+
+#[no_mangle]
+pub extern "C" fn completion_complete(_cb: rados_completion_t, arg: *mut c_void) -> () {
+    let waker = unsafe {
+        let p = arg as *mut Mutex<Option<Waker>>;
+        p.as_mut().unwrap()
+    };
+
+    let waker = waker.lock().unwrap().take();
+    match waker {
+        Some(w) => w.wake(),
+        None => {}
+    }
+}
+
+impl Drop for Completion<'_> {
+    fn drop(&mut self) {
+        // Ensure that after dropping the Completion, the AIO callback
+        // will not be called on our dropped waker Box.  Only necessary
+        // if we got as far as successfully starting an operation using
+        // the completion.
+        let am_complete = unsafe { rados_aio_is_complete(self.inner) } != 0;
+        if !am_complete {
+            unsafe {
+                let cancel_r = rados_aio_cancel(self.ioctx.ioctx, self.inner);
+
+                // It is unsound to proceed if the Objecter op is still in flight
+                assert!(cancel_r == 0 || cancel_r == -libc::ENOENT);
+            }
+        }
+
+        unsafe {
+            // Even if is_complete was true, librados might not be done with
+            // our callback: wait til it is.
+            assert_eq!(rados_aio_wait_for_complete_and_cb(self.inner), 0);
+        }
+
+        unsafe {
+            rados_aio_release(self.inner);
+        }
+    }
+}
+
+impl std::future::Future for Completion<'_> {
+    type Output = crate::error::RadosResult<u32>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        // Hold lock across the check of am_complete and subsequent waker registration
+        // to avoid deadlock if callback is invoked in between.
+        let mut waker_locked = self.waker.lock().unwrap();
+
+        let am_complete = unsafe { rados_aio_is_complete(self.inner) } != 0;
+
+        if am_complete {
+            // Unlock Waker so that completion callback can complete if racing with us.
+            drop(waker_locked);
+
+            // Ensure librados is finished with our callback ('complete' is true
+            // before it calls that)
+            unsafe {
+                let r = rados_aio_wait_for_complete_and_cb(self.inner);
+                assert_eq!(r, 0);
+            }
+
+            let r = unsafe { rados_aio_get_return_value(self.inner) };
+            let result = if r < 0 { Err(r.into()) } else { Ok(r) };
+            std::task::Poll::Ready(result.map(|e| e as u32))
+        } else {
+            // Register a waker
+            *waker_locked = Some(cx.waker().clone());
+
+            std::task::Poll::Pending
+        }
+    }
+}
+
+/// Completions are only created via this wrapper, in order to ensure
+/// that the Completion struct is only constructed around 'armed' rados_completion_t
+/// instances (i.e. those that have been used to start an I/O).
+pub(crate) fn with_completion<F>(ioctx: &IoCtx, f: F) -> RadosResult<Completion<'_>>
+where
+    F: FnOnce(rados_completion_t) -> libc::c_int,
+{
+    let mut waker = Box::new(Mutex::new(None));
+
+    let completion = unsafe {
+        let mut completion: rados_completion_t = std::ptr::null_mut();
+        let p: *mut Mutex<Option<Waker>> = &mut *waker;
+        let p = p as *mut c_void;
+
+        let r = rados_aio_create_completion2(p, Some(completion_complete), &mut completion);
+        if r != 0 {
+            panic!("Error {} allocating RADOS completion: out of memory?", r);
+        }
+
+        completion
+    };
+
+    let ret_code = f(completion);
+
+    if ret_code < 0 {
+        // On error dispatching I/O, drop the unused rados_completion_t
+        unsafe {
+            rados_aio_release(completion);
+            drop(completion)
+        }
+        Err(ret_code.into())
+    } else {
+        // Pass the rados_completion_t into a Future-implementing wrapper and await it.
+        Ok(Completion {
+            ioctx,
+            inner: completion,
+            waker,
+        })
+    }
+}

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -137,6 +137,7 @@ where
         if r != 0 {
             panic!("Error {} allocating RADOS completion: out of memory?", r);
         }
+        assert!(!completion.is_null());
 
         completion
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,6 +78,7 @@ pub mod utils;
 
 mod ceph_client;
 mod ceph_version;
+pub(crate) mod completion;
 mod mon_command;
 
 pub use crate::ceph_client::CephClient;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,6 +81,7 @@ mod ceph_version;
 pub(crate) mod completion;
 pub(crate) mod list_stream;
 mod mon_command;
+pub(crate) mod read_stream;
 
 pub use crate::ceph_client::CephClient;
 pub use crate::ceph_version::CephVersion;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,7 @@ pub(crate) mod completion;
 pub(crate) mod list_stream;
 mod mon_command;
 pub(crate) mod read_stream;
+pub(crate) mod write_sink;
 
 pub use crate::ceph_client::CephClient;
 pub use crate::ceph_version::CephVersion;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,6 +79,7 @@ pub mod utils;
 mod ceph_client;
 mod ceph_version;
 pub(crate) mod completion;
+pub(crate) mod list_stream;
 mod mon_command;
 
 pub use crate::ceph_client::CephClient;

--- a/src/list_stream.rs
+++ b/src/list_stream.rs
@@ -1,0 +1,125 @@
+use std::ffi::CStr;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use futures::executor::ThreadPool;
+use futures::task::SpawnExt;
+use futures::{Future, Stream};
+
+use crate::ceph::CephObject;
+use crate::error::{RadosError, RadosResult};
+use crate::rados::{rados_list_ctx_t, rados_nobjects_list_close, rados_nobjects_list_next};
+
+/// Wrap rados_list_ctx_t to make it Send (hold across .await)
+#[derive(Copy, Clone)]
+struct ListCtxHandle(rados_list_ctx_t);
+unsafe impl Send for ListCtxHandle {}
+
+/// A high level Stream interface to the librados 'nobjects_list' functionality.
+///
+/// librados does not expose asynchronous calls for object listing, so we use
+/// a background helper thread.
+pub struct ListStream {
+    ctx: ListCtxHandle,
+    workers: ThreadPool,
+
+    // We only have a single call to nobjects_list_next outstanding at
+    // any time: rely on underlying librados/Objecter to do
+    // batching/readahead
+    next: Option<Pin<Box<dyn Future<Output = Option<RadosResult<CephObject>>>>>>,
+}
+
+unsafe impl Send for ListStream {}
+
+impl ListStream {
+    pub fn new(ctx: rados_list_ctx_t) -> Self {
+        Self {
+            ctx: ListCtxHandle(ctx),
+            workers: ThreadPool::builder()
+                .pool_size(1)
+                .create()
+                .expect("Could not spawn worker thread"),
+            next: None,
+        }
+    }
+}
+
+impl Stream for ListStream {
+    type Item = Result<CephObject, RadosError>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        if self.next.is_none() {
+            let list_ctx = self.ctx;
+            self.next = Some(Box::pin(
+                self.workers
+                    .spawn_with_handle(async move {
+                        let mut entry_ptr: *mut *const ::libc::c_char = std::ptr::null_mut();
+                        let mut key_ptr: *mut *const ::libc::c_char = std::ptr::null_mut();
+                        let mut nspace_ptr: *mut *const ::libc::c_char = std::ptr::null_mut();
+                        unsafe {
+                            let r = rados_nobjects_list_next(
+                                list_ctx.0,
+                                &mut entry_ptr,
+                                &mut key_ptr,
+                                &mut nspace_ptr,
+                            );
+
+                            if r == -libc::ENOENT {
+                                None
+                            } else if r < 0 {
+                                Some(Err(r.into()))
+                            } else {
+                                let object_name =
+                                    CStr::from_ptr(entry_ptr as *const ::libc::c_char);
+                                let mut object_locator = String::new();
+                                let mut namespace = String::new();
+                                if !key_ptr.is_null() {
+                                    object_locator.push_str(
+                                        &CStr::from_ptr(key_ptr as *const ::libc::c_char)
+                                            .to_string_lossy(),
+                                    );
+                                }
+                                if !nspace_ptr.is_null() {
+                                    namespace.push_str(
+                                        &CStr::from_ptr(nspace_ptr as *const ::libc::c_char)
+                                            .to_string_lossy(),
+                                    );
+                                }
+
+                                Some(Ok(CephObject {
+                                    name: object_name.to_string_lossy().into_owned(),
+                                    entry_locator: object_locator,
+                                    namespace,
+                                }))
+                            }
+                        }
+                    })
+                    .expect("Could not spawn background task"),
+            ));
+        }
+
+        let result = self.next.as_mut().unwrap().as_mut().poll(cx);
+        match &result {
+            Poll::Pending => Poll::Pending,
+            _ => {
+                self.next = None;
+                result
+            }
+        }
+
+        // match self.next.as_mut().unwrap().as_mut().poll(cx) {
+        //     Poll::Pending => Poll: Pending,
+        //     Poll::Ready(None) => Poll::Ready(None),
+        //     Poll::Ready(Some(Err(rados_error))) => Poll::Ready(Some(Err(rados_error))),
+        //     Poll::Ready(Some(Ok(ceph_object))) => Poll::Ready(Some(Err(rados_error))),
+        // }
+    }
+}
+
+impl Drop for ListStream {
+    fn drop(&mut self) {
+        unsafe {
+            rados_nobjects_list_close(self.ctx.0);
+        }
+    }
+}

--- a/src/rados.rs
+++ b/src/rados.rs
@@ -606,6 +606,13 @@ extern "C" {
         cb_safe: rados_callback_t,
         pc: *mut rados_completion_t,
     ) -> ::libc::c_int;
+
+    pub fn rados_aio_create_completion2(
+        cb_arg: *mut ::std::os::raw::c_void,
+        cb_complete: rados_callback_t,
+        pc: *mut rados_completion_t,
+    ) -> ::libc::c_int;
+
     pub fn rados_aio_wait_for_complete(c: rados_completion_t) -> ::libc::c_int;
     pub fn rados_aio_wait_for_safe(c: rados_completion_t) -> ::libc::c_int;
     pub fn rados_aio_is_complete(c: rados_completion_t) -> ::libc::c_int;

--- a/src/rados.rs
+++ b/src/rados.rs
@@ -909,6 +909,32 @@ extern "C" {
         oid: *const ::libc::c_char,
         flags: ::libc::c_int,
     ) -> ::libc::c_int;
+
+    pub fn rados_aio_getxattr(
+        io: rados_ioctx_t,
+        o: *const ::libc::c_char,
+        completion: rados_completion_t,
+        name: *const ::libc::c_char,
+        buf: *mut ::libc::c_char,
+        len: size_t,
+    ) -> ::libc::c_int;
+
+    pub fn rados_aio_setxattr(
+        io: rados_ioctx_t,
+        o: *const ::libc::c_char,
+        completion: rados_completion_t,
+        name: *const ::libc::c_char,
+        buf: *const ::libc::c_char,
+        len: size_t,
+    ) -> ::libc::c_int;
+
+    pub fn rados_aio_rmxattr(
+        io: rados_ioctx_t,
+        o: *const ::libc::c_char,
+        completion: rados_completion_t,
+        name: *const ::libc::c_char,
+    ) -> ::libc::c_int;
+
     pub fn rados_lock_exclusive(
         io: rados_ioctx_t,
         o: *const ::libc::c_char,

--- a/src/read_stream.rs
+++ b/src/read_stream.rs
@@ -1,0 +1,183 @@
+// Copyright 2021 John Spray All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+
+use futures::{FutureExt, Stream};
+use std::ffi::CString;
+use std::future::Future;
+use std::os::raw::c_char;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use crate::ceph::IoCtx;
+use crate::completion::with_completion;
+use crate::error::RadosResult;
+use crate::rados::rados_aio_read;
+
+const DEFAULT_BUFFER_SIZE: usize = 4 * 1024 * 1024;
+const DEFAULT_CONCURRENCY: usize = 2;
+
+pub struct ReadStream<'a> {
+    ioctx: &'a IoCtx,
+
+    // Size of each RADOS read op
+    buffer_size: usize,
+
+    // Number of concurrent RADOS read ops to issue
+    concurrency: usize,
+
+    in_flight: Vec<IOSlot<'a>>,
+
+    next: u64,
+
+    object_name: String,
+
+    // Flag is set when we see a short read - means do not issue any more IOs,
+    // and return Poll::Ready(None) on next poll
+    done: bool,
+}
+
+unsafe impl Send for ReadStream<'_> {}
+
+impl<'a> ReadStream<'a> {
+    pub(crate) fn new(
+        ioctx: &'a IoCtx,
+        object_name: &str,
+        buffer_size: Option<usize>,
+        concurrency: Option<usize>,
+    ) -> Self {
+        let mut inst = Self {
+            ioctx,
+            buffer_size: buffer_size.unwrap_or(DEFAULT_BUFFER_SIZE),
+            concurrency: concurrency.unwrap_or(DEFAULT_CONCURRENCY),
+            in_flight: Vec::new(),
+            next: 0,
+            object_name: object_name.to_string(),
+            done: false,
+        };
+
+        // Start IOs early, don't wait for the first poll.
+        inst.maybe_issue();
+
+        inst
+    }
+}
+
+enum IOSlot<'a> {
+    Pending(Pin<Box<dyn Future<Output = (Vec<u8>, RadosResult<u32>)> + 'a>>),
+    Complete((Vec<u8>, RadosResult<u32>)),
+}
+
+impl<'a> ReadStream<'a> {
+    fn maybe_issue(&mut self) {
+        // Issue reads
+        while self.in_flight.len() < self.concurrency {
+            let read_at = self.next;
+            self.next += self.buffer_size as u64;
+
+            // Inefficient: copying out string to dodge ownership issues for the moment
+            let object_name_bg = self.object_name.clone();
+
+            // Grab items for use inside async{} block to avoid referencing self from in there.
+            let ioctx = self.ioctx;
+            let read_size = self.buffer_size;
+
+            // Use an async block to tie together the lifetime of a Vec and the Completion that uses it
+            let fut = async move {
+                let obj_name_str = CString::new(object_name_bg).expect("CString error");
+                let mut fill_buffer = Vec::with_capacity(read_size);
+                let completion = with_completion(ioctx, |c| unsafe {
+                    rados_aio_read(
+                        ioctx.ioctx,
+                        obj_name_str.as_ptr(),
+                        c,
+                        fill_buffer.as_mut_ptr() as *mut c_char,
+                        fill_buffer.capacity(),
+                        read_at,
+                    )
+                })
+                .expect("Can't issue read");
+
+                let result = completion.await;
+                if let Ok(rval) = &result {
+                    unsafe {
+                        let len = *rval as usize;
+                        assert!(len <= fill_buffer.capacity());
+                        fill_buffer.set_len(len);
+                    }
+                }
+
+                (fill_buffer, result)
+            };
+
+            let mut fut = Box::pin(fut);
+
+            let slot = match fut.as_mut().now_or_never() {
+                Some(result) => IOSlot::Complete(result),
+                None => IOSlot::Pending(fut),
+            };
+
+            self.in_flight.push(slot);
+        }
+    }
+}
+
+impl<'a> Stream for ReadStream<'a> {
+    type Item = RadosResult<Vec<u8>>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        if self.done {
+            // Our last read result was a short one: we know nothing else needs doing.
+            return Poll::Ready(None);
+        }
+
+        self.maybe_issue();
+
+        // Poll next read: maybe return pending if none is ready
+        let next_op = &mut self.in_flight[0];
+        let (buffer, result) = match next_op {
+            IOSlot::Complete(_) => {
+                let complete = self.in_flight.remove(0);
+                if let IOSlot::Complete(c) = complete {
+                    c
+                } else {
+                    panic!("Cannot happen")
+                }
+            }
+            IOSlot::Pending(fut) => match fut.as_mut().poll(cx) {
+                Poll::Pending => return Poll::Pending,
+                Poll::Ready(r) => {
+                    self.in_flight.remove(0);
+                    r
+                }
+            },
+        };
+
+        self.maybe_issue();
+
+        // A result is ready, handle it.
+        match result {
+            Ok(length) => {
+                if (length as usize) < self.buffer_size {
+                    // Cancel outstanding ops
+                    self.in_flight.clear();
+
+                    // Flag to return Ready(None) on next call to poll.
+                    self.done = true;
+                }
+                Poll::Ready(Some(Ok(buffer)))
+            }
+            Err(e) => Poll::Ready(Some(Err(e))),
+        }
+    }
+}

--- a/src/write_sink.rs
+++ b/src/write_sink.rs
@@ -1,0 +1,123 @@
+use futures::{FutureExt, Sink, Stream};
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use crate::ceph::IoCtx;
+use crate::completion::with_completion;
+use crate::error::{RadosError, RadosResult};
+use crate::rados::rados_aio_write;
+use futures::stream::FuturesUnordered;
+use std::ffi::CString;
+use std::os::raw::c_char;
+
+const DEFAULT_CONCURRENCY: usize = 2;
+
+pub struct WriteSink<'a> {
+    ioctx: &'a IoCtx,
+    in_flight: Pin<Box<FuturesUnordered<Pin<Box<dyn Future<Output = RadosResult<u32>> + 'a>>>>>,
+    object_name: String,
+
+    // Offset into object where the next write will land
+    next: u64,
+
+    // How many RADOS ops in flight at same time?
+    concurrency: usize,
+}
+
+unsafe impl Send for WriteSink<'_> {}
+
+impl<'a> WriteSink<'a> {
+    pub fn new(ioctx: &'a IoCtx, object_name: &str, concurrency: Option<usize>) -> Self {
+        let concurrency = concurrency.unwrap_or(DEFAULT_CONCURRENCY);
+        assert!(concurrency > 0);
+
+        Self {
+            ioctx,
+            in_flight: Box::pin(FuturesUnordered::new()),
+            object_name: object_name.to_string(),
+            next: 0,
+            concurrency,
+        }
+    }
+
+    fn trim_in_flight(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        target_len: usize,
+    ) -> Poll<Result<(), <Self as Sink<Vec<u8>>>::Error>> {
+        while self.in_flight.len() > target_len {
+            match self.in_flight.as_mut().poll_next(cx) {
+                Poll::Pending => return Poll::Pending,
+                Poll::Ready(None) => {
+                    // (because we check for in_flight size first)
+                    unreachable!()
+                }
+                Poll::Ready(Some(result)) => match result {
+                    Err(e) => return Poll::Ready(Err(e)),
+                    Ok(sz) => {
+                        debug!("trim_in_flight: IO completed with r={}", sz);
+                    }
+                },
+            };
+        }
+
+        // Nothing left in flight, we're done
+        Poll::Ready(Ok(()))
+    }
+}
+
+impl<'a> Sink<Vec<u8>> for WriteSink<'a> {
+    type Error = RadosError;
+
+    fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        // If we have fewer than 1 slots available, this will try to wait on some outstanding futures
+        let target = self.as_ref().concurrency - 1;
+        if self.in_flight.len() > target {
+            self.trim_in_flight(cx, target)
+        } else {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    fn start_send(mut self: Pin<&mut Self>, item: Vec<u8>) -> Result<(), Self::Error> {
+        let ioctx = self.ioctx;
+        let obj_name_str = CString::new(self.object_name.clone()).expect("CString error");
+        let write_at = self.next;
+        self.next += item.len() as u64;
+
+        let mut fut = Box::pin(async move {
+            let c = with_completion(ioctx, |c| unsafe {
+                rados_aio_write(
+                    ioctx.ioctx,
+                    obj_name_str.as_ptr(),
+                    c,
+                    item.as_ptr() as *mut c_char,
+                    item.len(),
+                    write_at,
+                )
+            })?;
+
+            c.await
+        });
+
+        // Kick the async{} future to get the RADOS op sent
+        match fut.as_mut().now_or_never() {
+            Some(Ok(_)) => Ok(()),
+            Some(Err(e)) => return Err(e),
+            None => {
+                self.in_flight.push(fut);
+                Ok(())
+            }
+        }
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.trim_in_flight(cx, 0)
+    }
+
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        // There is no special work to be done on close
+        self.poll_flush(cx)
+    }
+}


### PR DESCRIPTION
This PR adds an  async/await compatible interface for librados's aio methods.

A new Completion type wraps  Ceph's completions into a `Future`, including the  cancel-on-drop behaviour expected of rust futures.

For reading and writing large  objects, there are  streaming variants that return `Stream`/`Sink` compatible  objects, with  configurable  chunk sizes and numbers of IOs in flight.
