### PR TITLE
Add support to latest ceph stable version: Quincy

### DIFF
--- a/src/ceph_version.rs
+++ b/src/ceph_version.rs
@@ -40,6 +40,7 @@ pub enum CephVersion {
     Nautilus,
     Octopus,
     Pacific,
+    Quincy,
 }
 
 impl FromStr for CephVersion {
@@ -61,6 +62,7 @@ impl FromStr for CephVersion {
                 version_parts.next(),
             ) {
                 match major {
+                    "17" => return Ok(Quincy),
                     "16" => return Ok(Pacific),
                     "15" => return Ok(Octopus),
                     "14" => return Ok(Nautilus),


### PR DESCRIPTION
Connecting to a Quincy cluster fails without this update.