### PR TITLE
chore: update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,30 +17,27 @@ keywords = ["ceph", "storage"]
 # This is a list of up to five categories where this crate would fit.
 # Categories are a fixed list available at crates.io/category_slugs, and
 # they must match exactly.
-categories = ["filesystem"]
+categories = ["api-bindings", "command-line-utilities", "external-ffi-bindings"]
 
 documentation = "https://docs.rs/ceph"
 repository = "https://github.com/ceph/ceph-rust"
 homepage = "https://github.com/ceph/ceph-rust"
 
 description = """
-Official Ceph-rust. A rust-lang specific interface to Ceph librados and Admin Sockets. You can create a Ceph development environment with the
-Chef automation tools: https://github.com/bloomberg/chef-bcs or with ceph-ansible. Chef-bcs uses the ceph-chef cookbook
-created and manage at github.com/ceph/ceph-chef. It will build out a full Ceph environment which you can then use
-for development etc. See README.md for details.
+Official Ceph-rust. A rust-lang specific interface to Ceph librados and Admin Sockets.
 """
-edition = "2018"
+edition = "2021"
 
 [dependencies]
-bitflags = "1.2.1"
+bitflags = "~1.2"
 byteorder = "1"
 libc = "~0.2"
 nom = "6"
 serde_derive = "1"
 serde = "1"
 serde_json = "1"
-uuid = { version = "~0.8", features = ["serde"] }
-nix = "0.21"
+uuid = { version = "~1", features = ["serde"] }
+nix = "0.29"
 tracing = "0.1"
 
 [features]

--- a/src/error.rs
+++ b/src/error.rs
@@ -139,6 +139,6 @@ impl From<Error> for RadosError {
 }
 impl From<i32> for RadosError {
     fn from(err: i32) -> RadosError {
-        RadosError::ApiError(nix::errno::Errno::from_i32(-err))
+        RadosError::ApiError(nix::errno::Errno::from_raw(-err))
     }
 }


### PR DESCRIPTION
To me, `2018` and `2021` both build and both have the same clippy issues.

https://github.com/ceph/ceph-rust/issues/101