### PR TITLE
chore: upgrade nix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ serde_derive = "1"
 serde = "1"
 serde_json = "1"
 uuid = { version = "~0.8", features = ["serde"] }
-nix = "0.21"
+nix = "0.29"
 tracing = "0.1"
 
 [features]

--- a/src/error.rs
+++ b/src/error.rs
@@ -139,6 +139,6 @@ impl From<Error> for RadosError {
 }
 impl From<i32> for RadosError {
     fn from(err: i32) -> RadosError {
-        RadosError::ApiError(nix::errno::Errno::from_i32(-err))
+        RadosError::ApiError(nix::errno::Errno::from_raw(-err))
     }
 }


### PR DESCRIPTION
Upgrades nix to 0.29 per https://rustsec.org/advisories/RUSTSEC-2021-0119
