### PR TITLE
fix memleak in connect_to_ceph fail

### DIFF
--- a/src/ceph.rs
+++ b/src/ceph.rs
@@ -393,6 +393,13 @@ pub fn connect_to_ceph(user_id: &str, config_file: &str) -> RadosResult<Rados> {
         if ret_code < 0 {
             return Err(ret_code.into());
         }
+        // Instantiate Rados struct to call shutdown on drop.
+        // Doc specifies that it's not necessary to call rados_shutdown if
+        // rados_connect hasn't run, but that seems incorrect.
+        let rados = Rados {
+            rados: cluster_handle,
+            phantom: PhantomData,
+        };
         let ret_code = rados_conf_read_file(cluster_handle, conf_file.as_ptr());
         if ret_code < 0 {
             return Err(ret_code.into());
@@ -401,10 +408,7 @@ pub fn connect_to_ceph(user_id: &str, config_file: &str) -> RadosResult<Rados> {
         if ret_code < 0 {
             return Err(ret_code.into());
         }
-        Ok(Rados {
-            rados: cluster_handle,
-            phantom: PhantomData,
-        })
+        Ok(rados)
     }
 }
 


### PR DESCRIPTION
It appears that the `Rados` struct not being constructed after `rados_create` succeeding but before other fallible calls may result in never calling the destructor that should be called after a successful call to `rados_create`, leading to a memory leak.

This fixes it, by moving the construction of the `Rados` struct just after the successful `rados_create` call.