### PR TITLE
Reexport nix::Errno

### DIFF
--- a/examples/rados_striper.rs
+++ b/examples/rados_striper.rs
@@ -1,6 +1,9 @@
 #[cfg(feature = "rados_striper")]
 use {
-    ceph::ceph as ceph_helpers, ceph::error::RadosError, nix::errno::Errno, std::env, std::str,
+    ceph::ceph as ceph_helpers,
+    ceph::error::{Errno, RadosError},
+    std::env,
+    std::str,
     std::sync::Arc,
 };
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -25,6 +25,8 @@ use uuid::Error as UuidError;
 
 extern crate nix;
 
+pub use nix::errno::Errno;
+
 /// Custom error handling for the library
 #[derive(Debug)]
 pub enum RadosError {
@@ -32,7 +34,7 @@ pub enum RadosError {
     NulError(NulError),
     Error(String),
     IoError(Error),
-    ApiError(nix::errno::Errno),
+    ApiError(Errno),
     IntoStringError(IntoStringError),
     ParseIntError(ParseIntError),
     ParseBoolError(ParseBoolError),
@@ -139,6 +141,6 @@ impl From<Error> for RadosError {
 }
 impl From<i32> for RadosError {
     fn from(err: i32) -> RadosError {
-        RadosError::ApiError(nix::errno::Errno::from_raw(-err))
+        RadosError::ApiError(Errno::from_raw(-err))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,5 +87,3 @@ pub use crate::mon_command::MonCommand;
 
 pub type JsonData = serde_json::Value;
 pub type JsonValue = serde_json::Value;
-
-pub use nix;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,3 +87,5 @@ pub use crate::mon_command::MonCommand;
 
 pub type JsonData = serde_json::Value;
 pub type JsonValue = serde_json::Value;
+
+pub use nix;


### PR DESCRIPTION
This is useful because the Error enum in its ApiError error variant exports that type, so in order to match on the error value it's necessary to use the same version of `nix` as this crate uses.

The idiom in this case is to reexport `nix` (or reexporting `Errno` would likely be fine as well, but I'm not sure if `nix` leaks in other ways maybe so I propose exporting the entire `nix` to be sure that it's correct.)